### PR TITLE
fix(plugin-vue): don't inline ts scripts during build

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -268,7 +268,7 @@ async function genScriptCode(
   if (script) {
     // If the script is js/ts and has no external src, it can be directly placed
     // in the main module.
-    if ((!script.lang || script.lang === 'ts') && !script.src) {
+    if ((!script.lang || (script.lang === 'ts' && options.devServer)) && !script.src) {
       scriptCode = options.compiler.rewriteDefault(
         script.content,
         '_sfc_main',


### PR DESCRIPTION
Partial revert of 93d9a2d
When building, TS scripts must not be inlined so that loaders (e.g. rollup-plugin-typescript2) are correctly applied.

Fixes #5044, #5795, #7908

<!-- Thank you for contributing! -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
